### PR TITLE
Handle ending blank line.

### DIFF
--- a/CsvToTable.js
+++ b/CsvToTable.js
@@ -43,6 +43,25 @@
         return row !== "";
     }
 
+    // polyfill `.filter()` for ECMAScript <5.1
+    // `f` must be pure (not modify original array).
+    if (!Array.prototype.filter) {
+      Array.prototype.filter = function(f) {
+        "use strict";
+        var p = arguments[1];
+        var o = Object(this);
+        var len = o.length;
+        for (var i = 0; i < len; i++) {
+          if (i in o) {
+              var v = o[i];
+              f.call(p, v, i, o);
+          }
+        }
+
+        return this;
+      };
+    }
+
 	function buildTable() {
 		getCSV.call(this).then(function(response){
 			var allRows = response.split(/\r?\n|\r/).filter(isNotEmpty);

--- a/CsvToTable.js
+++ b/CsvToTable.js
@@ -33,7 +33,7 @@
 				 	reject(Error('Error fetching data.'));
 				};
 				request.send();
-			});	
+			});
 		}catch(err){
 			console.error(err);
 		}
@@ -42,6 +42,10 @@
 	function buildTable() {
 		getCSV.call(this).then(function(response){
 			var allRows = response.split(/\r?\n|\r/);
+			// Remove ending line break.
+			if (allRows[allRows.length - 1] === "") {
+				allRows.pop();
+			}
 	        var table = '<table>';
 	        for (var singleRow = 0; singleRow < allRows.length; singleRow++) {
 	            if (singleRow === 0) {
@@ -78,5 +82,5 @@
 			console.error(error);
 		});
 	}
-	
+
 }());

--- a/CsvToTable.js
+++ b/CsvToTable.js
@@ -39,13 +39,13 @@
 		}
 	}
 
+    function isNotEmpty(row) {
+        return row !== "";
+    }
+
 	function buildTable() {
 		getCSV.call(this).then(function(response){
-			var allRows = response.split(/\r?\n|\r/);
-			// Remove ending line break.
-			if (allRows[allRows.length - 1] === "") {
-				allRows.pop();
-			}
+			var allRows = response.split(/\r?\n|\r/).filter(isNotEmpty);
 	        var table = '<table>';
 	        for (var singleRow = 0; singleRow < allRows.length; singleRow++) {
 	            if (singleRow === 0) {


### PR DESCRIPTION
> The last record in the file may or may not have an ending line break.
> -- [RFC4180](https://tools.ietf.org/html/rfc4180)

Previous implementation converts a csv file with ending line break
to an HTML table with an additional empty row:

```
+-----+-------+
|Last | field |
+-----+-------+
|     |
+-----+
```

This commit correctly handles ending blank line,
i.e. converting to an HTML table without redundant empty row.

Permission to use, copy, modify, and/or distribute this commit
for any purpose with or without fee is hereby granted.

---

 CsvToTable.js | 10 +++++++---
 1 file changed, 7 insertions(+), 3 deletions(-)
