### PR TITLE
Use the File API instead of xmlhttprequest since that is deprecated

### DIFF
--- a/CsvToTable.js
+++ b/CsvToTable.js
@@ -1,104 +1,90 @@
 (function(){
 
-	// Constructor method
-	this.CsvToTable = function(){
-		this.csvFile = null;
+  // Constructor method
+  this.CsvToTable = function(){
+    this.csvFileHandle = null;
 
-		// Create options by extending defaults with the passed in arugments
-    	if (arguments[0] && typeof arguments[0] === "object") {
-      		this.options = arguments[0];
-    	}
-
-	}
-
-	CsvToTable.prototype.run = function() {
-		return buildTable.call(this);
-	}
-
-	function getCSV() {
-		try{
-			var csvfile = this.options.csvFile;
-			return new Promise(function(resolve, reject) {
-				var request = new XMLHttpRequest();
-				request.open("GET", csvfile, true);
-				request.onload = function() {
-				    if (request.status == 200) {
-				        resolve(request.response);
-				    } else {
-				        reject(Error(request.statusText));
-				    }
-				};
-
-				request.onerror = function() {
-				 	reject(Error('Error fetching data.'));
-				};
-				request.send();
-			});
-		}catch(err){
-			console.error(err);
-		}
-	}
-
-    function isNotEmpty(row) {
-        return row !== "";
+    // Create options by extending defaults with the passed in arguments
+    if (arguments[0] && typeof arguments[0] === "object") {
+      this.options = arguments[0];
     }
 
-    // polyfill `.filter()` for ECMAScript <5.1
-    // `f` must be pure (not modify original array).
-    if (!Array.prototype.filter) {
-      Array.prototype.filter = function(f) {
-        "use strict";
-        var p = arguments[1];
-        var o = Object(this);
-        var len = o.length;
-        for (var i = 0; i < len; i++) {
-          if (i in o) {
-              var v = o[i];
-              f.call(p, v, i, o);
-          }
+  }
+
+  CsvToTable.prototype.run = function() {
+    return buildTable.call(this);
+  }
+
+  function getCSV() {
+    try{
+      
+      // Returns a Promise
+      return this.options.csvFileHandle.text();
+    }catch(err){
+      console.error(err);
+    }
+  }
+
+  function isNotEmpty(row) {
+    return row !== "";
+  }
+
+  // polyfill `.filter()` for ECMAScript <5.1
+  // `f` must be pure (not modify original array).
+  if (!Array.prototype.filter) {
+    Array.prototype.filter = function(f) {
+      "use strict";
+      var p = arguments[1];
+      var o = Object(this);
+      var len = o.length;
+      for (var i = 0; i < len; i++) {
+        if (i in o) {
+          var v = o[i];
+          f.call(p, v, i, o);
         }
+      }
 
-        return this;
-      };
-    }
+      return this;
+    };
+  }
 
-	function buildTable() {
-		getCSV.call(this).then(function(response){
-			var allRows = response.split(/\r?\n|\r/).filter(isNotEmpty);
-	        var table = '<table>';
-	        for (var singleRow = 0; singleRow < allRows.length; singleRow++) {
-	            if (singleRow === 0) {
-	                table += '<thead>';
-	                table += '<tr>';
-	            } else {
-	                table += '<tr>';
-	            }
-	            var rowCells = allRows[singleRow].split(',');
-	            for(var rowCell = 0; rowCell < rowCells.length; rowCell++){
-	                if(singleRow === 0){
-	                    table += '<th>';
-	                    table += rowCells[rowCell];
-	                    table += '</th>';
-	                } else {
-	                    table += '<td>';
-	                    table += rowCells[rowCell];
-	                    table += '</td>';
-	                }
-	            }
-	            if (singleRow === 0) {
-	                table += '</tr>';
-	                table += '</thead>';
-	                table += '<tbody>';
-	            } else {
-	                table += '</tr>';
-	            }
-	        }
-	        table += '</tbody>';
-	        table += '</table>';
-
-	        document.body.innerHTML += table;
-		}, function(error){
-			console.error(error);
-		});
+  function buildTable() {
+    getCSV.call(this).then(function(response){
+      var allRows = response.split(/\r?\n|\r/).filter(isNotEmpty);
+      var table = '<table>';
+      for (var singleRow = 0; singleRow < allRows.length; singleRow++) {
+	if (singleRow === 0) {
+	  table += '<thead>';
+	  table += '<tr>';
+	} else {
+	  table += '<tr>';
 	}
+	var rowCells = allRows[singleRow].split(',');
+	for(var rowCell = 0; rowCell < rowCells.length; rowCell++){
+	  if(singleRow === 0){
+	    table += '<th>';
+	    table += rowCells[rowCell];
+	    table += '</th>';
+	  } else {
+	    table += '<td>';
+	    table += rowCells[rowCell];
+	    table += '</td>';
+	  }
+	}
+	if (singleRow === 0) {
+	  table += '</tr>';
+	  table += '</thead>';
+	  table += '<tbody>';
+	} else {
+	  table += '</tr>';
+	}
+      }
+      table += '</tbody>';
+      table += '</table>';
+
+      document.body.innerHTML += table;
+    }, function(error){
+      console.error(error);
+    });
+  }
 }());

--- a/CsvToTable.js
+++ b/CsvToTable.js
@@ -1,90 +1,90 @@
 (function(){
 
-  // Constructor method
-  this.CsvToTable = function(){
-    this.csvFileHandle = null;
+	// Constructor method
+	this.CsvToTable = function(){
+		this.csvFileHandle = null;
 
-    // Create options by extending defaults with the passed in arguments
-    if (arguments[0] && typeof arguments[0] === "object") {
-      this.options = arguments[0];
-    }
+		// Create options by extending defaults with the passed in arguments
+		if (arguments[0] && typeof arguments[0] === "object") {
+			this.options = arguments[0];
+		}
 
-  }
+	}
 
-  CsvToTable.prototype.run = function() {
-    return buildTable.call(this);
-  }
+	CsvToTable.prototype.run = function() {
+		return buildTable.call(this);
+	}
 
-  function getCSV() {
-    try{
-      
-      // Returns a Promise
-      return this.options.csvFileHandle.text();
-    }catch(err){
-      console.error(err);
-    }
-  }
+	function getCSV() {
+		try{
+			
+			// Returns a Promise
+			return this.options.csvFileHandle.text();
+		}catch(err){
+			console.error(err);
+		}
+	}
 
-  function isNotEmpty(row) {
-    return row !== "";
-  }
+	function isNotEmpty(row) {
+		return row !== "";
+	}
 
-  // polyfill `.filter()` for ECMAScript <5.1
-  // `f` must be pure (not modify original array).
-  if (!Array.prototype.filter) {
-    Array.prototype.filter = function(f) {
-      "use strict";
-      var p = arguments[1];
-      var o = Object(this);
-      var len = o.length;
-      for (var i = 0; i < len; i++) {
-        if (i in o) {
-          var v = o[i];
-          f.call(p, v, i, o);
-        }
-      }
+	// polyfill `.filter()` for ECMAScript <5.1
+	// `f` must be pure (not modify original array).
+	if (!Array.prototype.filter) {
+		Array.prototype.filter = function(f) {
+			"use strict";
+			var p = arguments[1];
+			var o = Object(this);
+			var len = o.length;
+			for (var i = 0; i < len; i++) {
+				if (i in o) {
+					var v = o[i];
+					f.call(p, v, i, o);
+				}
+			}
 
-      return this;
-    };
-  }
+			return this;
+		};
+	}
 
-  function buildTable() {
-    getCSV.call(this).then(function(response){
-      var allRows = response.split(/\r?\n|\r/).filter(isNotEmpty);
-      var table = '<table>';
-      for (var singleRow = 0; singleRow < allRows.length; singleRow++) {
+	function buildTable() {
+		getCSV.call(this).then(function(response){
+			var allRows = response.split(/\r?\n|\r/).filter(isNotEmpty);
+			var table = '<table>';
+			for (var singleRow = 0; singleRow < allRows.length; singleRow++) {
 	if (singleRow === 0) {
-	  table += '<thead>';
-	  table += '<tr>';
+		table += '<thead>';
+		table += '<tr>';
 	} else {
-	  table += '<tr>';
+		table += '<tr>';
 	}
 	var rowCells = allRows[singleRow].split(',');
 	for(var rowCell = 0; rowCell < rowCells.length; rowCell++){
-	  if(singleRow === 0){
-	    table += '<th>';
-	    table += rowCells[rowCell];
-	    table += '</th>';
-	  } else {
-	    table += '<td>';
-	    table += rowCells[rowCell];
-	    table += '</td>';
-	  }
+		if(singleRow === 0){
+			table += '<th>';
+			table += rowCells[rowCell];
+			table += '</th>';
+		} else {
+			table += '<td>';
+			table += rowCells[rowCell];
+			table += '</td>';
+		}
 	}
 	if (singleRow === 0) {
-	  table += '</tr>';
-	  table += '</thead>';
-	  table += '<tbody>';
+		table += '</tr>';
+		table += '</thead>';
+		table += '<tbody>';
 	} else {
-	  table += '</tr>';
+		table += '</tr>';
 	}
-      }
-      table += '</tbody>';
-      table += '</table>';
+			}
+			table += '</tbody>';
+			table += '</table>';
 
-      document.body.innerHTML += table;
-    }, function(error){
-      console.error(error);
-    });
-  }
+			document.body.innerHTML += table;
+		}, function(error){
+			console.error(error);
+		});
+	}
 }());

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # CsvToTable
-Parse the local CSV file using pure javascript and convert to HTML table
+Parse a user local CSV file using pure javascript and convert it to a HTML table
 
 Check out the working demo: http://yasharma.github.io/CsvToTable/
 
@@ -12,22 +12,11 @@ git clone git@github.com:yasharma/CsvToTable.git
 cd CsvToTable
 ```
 
-#### 2. Add your CSV file to current folder
+#### 2. Open `index.html` and select your CSV file using the standardized file upload element
 
-#### 3. In `index.html` configure the `CsvToTable()` constructor function
-
-```html
-<script>
-	var csvtotable = new CsvToTable({
-		csvFile: 'your csv filename/filepath' 
-	});
-	csvtotable.run();
-</script>
-```
-
-Available options:
-* `csvFile` Path to your CSV file.
+#### 3. The table renders as soon as the file is selected
 
 ## License
 
 This project is licensed under the [GNU General Public License](https://opensource.org/licenses/GPL-3.0).
+

--- a/index.html
+++ b/index.html
@@ -1,37 +1,21 @@
 <!DOCTYPE html>
 <html>
-<head>
-	<title>Javascript</title>
-	<style>
-		table {
-		  margin: 0 auto;
-		  text-align: center;
-		  border-collapse: collapse;
-		  border: 1px solid #d4d4d4;
-		  height: 500px; 
-		}
-		 
-		tr:nth-child(even) {
-		  background: #d4d4d4;
-		}
-		 
-		th, td {
-		  padding: 10px 30px;
-		}
-		 
-		th {
-		  border-bottom: 1px solid #d4d4d4;
-		}
-	</style>
-</head>
-<body>
+  <head>
+    <title>Javascript</title>
+    <meta charset="utf-8" />
+    <link rel="stylesheet" type="text/css" href="style.css" />
+  </head>
+  <body>
+    <input type="file" accept=".csv" onchange="handleFile(this.files)" />
 
-<script src="CsvToTable.js"></script>
-<script>
+    <script src="CsvToTable.js"></script>
+    <script>
+      function handleFile(files){
 	var csvtotable = new CsvToTable({
-		csvFile: 'MOCK_DATA.csv'
+	  csvFileHandle: files[0]
 	});
 	csvtotable.run();
-</script>
-</body>
+      }
+    </script>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,21 +1,21 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title>Javascript</title>
-    <meta charset="utf-8" />
-    <link rel="stylesheet" type="text/css" href="style.css" />
-  </head>
-  <body>
-    <input type="file" accept=".csv" onchange="handleFile(this.files)" />
+	<head>
+		<title>Javascript</title>
+		<meta charset="utf-8" />
+		<link rel="stylesheet" type="text/css" href="style.css" />
+	</head>
+	<body>
+		<input type="file" accept=".csv" onchange="handleFile(this.files)" />
 
-    <script src="CsvToTable.js"></script>
-    <script>
-      function handleFile(files){
+		<script src="CsvToTable.js"></script>
+		<script>
+			function handleFile(files){
 	var csvtotable = new CsvToTable({
-	  csvFileHandle: files[0]
+		csvFileHandle: files[0]
 	});
 	csvtotable.run();
-      }
-    </script>
-  </body>
+			}
+		</script>
+	</body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,19 @@
+table {
+    margin: 0 auto;
+    text-align: center;
+    border-collapse: collapse;
+    border: 1px solid #d4d4d4;
+    height: 500px; 
+}
+
+tr:nth-child(even) {
+    background: #d4d4d4;
+}
+
+th, td {
+    padding: 10px 30px;
+}
+
+th {
+    border-bottom: 1px solid #d4d4d4;
+}


### PR DESCRIPTION
xmlhttprequests/fetch can no longer access server "local" files even on Firefox. The File API is an almost drop in replacement since it also works with promises. I also added a standard file upload element to the index page which supplies the FileList object where an individual File can be accessed. I also moved the styling to an external file for convenience.

As of 5th of September 2019 the File API, which simply passes through the Blob API, supports .text() which returns a promise that resolves into a string. [See this Firefox update](https://developer.mozilla.org/sv-SE/docs/Mozilla/Firefox/Releases/69#APIs). [Here's](https://developer.mozilla.org/en-US/docs/Web/API/Blob/text) the Blob.text documentation even though it's quite simple.

I've tested it on my Windows 10 and my Ubuntu 18.04 LTS machine using both Firefox 69 and Chrome 76. The feature is marked as experimental in Firefox on [caniuse](https://caniuse.com/#feat=mdn-api_blob_text) meaning it won't work for old broswers *however* the current method doesn't work at all which is a compelling argument to change it in my opinion.